### PR TITLE
change parameters for Dancer2 compatibility and so tests pass

### DIFF
--- a/lib/Dancer2/Plugin/REST.pm
+++ b/lib/Dancer2/Plugin/REST.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Carp 'croak';
 
-use Dancer2 ':syntax';
+use Dancer2 ;
 use Dancer2::Plugin;
 
 use Moo::Role;


### PR DESCRIPTION
:syntax' has been removed from Dancer2

use Dancer2::Plugin::REST;  

fails like this:
/home/web/perl5/lib/perl5/Dancer2.pm:53:parameters to 'use Dancer2' should be one of : 'key => value', ':tests', ':script', or !<keyword>, where <keyword> is a DSL keyword you don't want to import

Tests fail like this:

t/02_prepare_serializer_for_format.t .. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
parameters to 'use Dancer2' should be one of : 'key => value', ':tests', ':script', or !<keyword>, where <keyword> is a DSL keyword you don't want to import at /home/web/perl5/lib/perl5/Dancer2.pm line 53.lugin-REST-0.12/blib/lib/Dancer2/Plugin/REST.pm line 15.

Probably more to do, but this simple change allows test to pass.
